### PR TITLE
Add support for 5.15-23.08 runtime.

### DIFF
--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -1,10 +1,10 @@
 {
     "id": "org.kde.KStyle.Kvantum",
-    "branch": "5.15-22.08",
+    "branch": "5.15-23.08",
     "runtime": "org.kde.Platform",
     "build-extension": true,
     "sdk": "org.kde.Sdk",
-    "runtime-version": "5.15-22.08",
+    "runtime-version": "5.15-23.08",
     "separate-locales": false,
     "appstream-compose": false,
     "build-options": {


### PR DESCRIPTION
This needs to be merged as `branch/5.15-23.08` in order to do anything meaningful, and GitHub doesn't seem to let you propose a pull request like that. Still, it was confirmed to build fine, so I'm leaving this here for anyone to take this ball and run with it. Closes #22.

Qt6 will be the next big hurdle. :)