### PR TITLE
Add support for 6.6 runtime.

### DIFF
--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -1,10 +1,10 @@
 {
     "id": "org.kde.KStyle.Kvantum",
-    "branch": "5.15-22.08",
+    "branch": "6.6",
     "runtime": "org.kde.Platform",
     "build-extension": true,
     "sdk": "org.kde.Sdk",
-    "runtime-version": "5.15-22.08",
+    "runtime-version": "6.6",
     "separate-locales": false,
     "appstream-compose": false,
     "build-options": {
@@ -14,6 +14,9 @@
         {
             "name": "kvantum",
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DENABLE_QT5=OFF"
+            ],
             "build-commands": [
                 "install -Dm755 -t ${FLATPAK_DEST}/styles/ style/libkvantum.so"
             ],
@@ -36,7 +39,7 @@
                     "type": "shell",
                     "dest": "Kvantum/style",
                     "commands": [
-                        "sed \"s|\\${_Qt5_PLUGIN_INSTALL_DIR}|${FLATPAK_DEST}|g\" -i CMakeLists.txt"
+                        "sed \"s|\\${_Qt6_PLUGIN_INSTALL_DIR}|${FLATPAK_DEST}|g\" -i CMakeLists.txt"
                     ]
                 }
             ]


### PR DESCRIPTION
Along with #24, part of fixing #16.

Same verse as over there: needs to be `branch/6.6` to be meaningful, and I still can't do that here.

I'm not sure which branch ProtonUp-Qt is currently targeting, but I tested that Kvantum works on it using the `QT_STYLE_OVERRIDE` env var.